### PR TITLE
Implement query filters for quotes list

### DIFF
--- a/src/entity/crm/quote.ts
+++ b/src/entity/crm/quote.ts
@@ -145,7 +145,7 @@ export class Quote extends BaseEntity {
 }
 
 @Entity({ name: "crm_quote_item" })
-@Tree("materialized-path")
+@Tree("closure-table")
 export class QuoteItem extends BaseEntity {
   @PrimaryGeneratedColumn()
   id: number;

--- a/src/routes/quote.ts
+++ b/src/routes/quote.ts
@@ -11,7 +11,13 @@ const getQuotes = async (request: Request, response: Response) => {
     response.status(401).send("Unauthorized");
     return;
   }
-  const quotes = await quoteService.getQuotes();
+  const quotes = await quoteService.getQuotes({
+    page: parseInt(request.query.page as string),
+    pageSize: parseInt(request.query.pageSize as string),
+    type: request.query.type as string,
+    quoteName: request.query.quoteName as string,
+    customerName: request.query.customerName as string,
+  });
   response.send(quotes);
 };
 

--- a/src/services/crm/quoteService.ts
+++ b/src/services/crm/quoteService.ts
@@ -276,8 +276,37 @@ class QuoteService {
     return await QuoteItem.delete(quoteItemId);
   };
 
-  getQuotes = async () => {
-    return await Quote.find({ where: { type: "history" } });
+  getQuotes = async (params?: {
+    page?: number;
+    pageSize?: number;
+    type?: string;
+    quoteName?: string;
+    customerName?: string;
+  }) => {
+    const { page = 1, pageSize = 20, type, quoteName, customerName } =
+      params || {};
+
+    const query = Quote.createQueryBuilder("quote");
+    if (type) {
+      query.andWhere("quote.type = :type", { type });
+    }
+    if (quoteName) {
+      query.andWhere("quote.quoteName LIKE :quoteName", {
+        quoteName: `%${quoteName}%`,
+      });
+    }
+    if (customerName) {
+      query.andWhere("quote.customerName LIKE :customerName", {
+        customerName: `%${customerName}%`,
+      });
+    }
+
+    const [list, total] = await query
+      .skip((page - 1) * pageSize)
+      .take(pageSize)
+      .getManyAndCount();
+
+    return { list, total };
   };
   getQuoteDetail = async (quoteId: number) => {
     const itemTreeRepository = PgDataSource.getTreeRepository(QuoteItem);


### PR DESCRIPTION
## Summary
- support pagination and filtering for listing quotes
- forward query params from the route
- switch QuoteItem to closure-table tree

## Testing
- `npm test` *(fails: 403 Forbidden - GET https://registry.npmjs.org/nodemon)*
- `npm run build` *(fails: Cannot find module errors)*

------
https://chatgpt.com/codex/tasks/task_e_68494fc2e00883279d845faf3d7af7de