### PR TITLE
Check duplicate order ID when creating quote

### DIFF
--- a/src/services/crm/quoteService.ts
+++ b/src/services/crm/quoteService.ts
@@ -235,10 +235,15 @@ class QuoteService {
       customerName: string;
       customerId: string;
       quoteId: string;
+      orderId?: string;
       date: string;
     },
     creatorId: string
   ) => {
+    if (params.orderId) {
+      const exist = await Quote.findOne({ where: { orderId: params.orderId } });
+      if (exist) return { message: "订单号重复" } as any;
+    }
     return await Quote.create({
       ...params,
       currencyType: "CNY",


### PR DESCRIPTION
## Summary
- prevent duplicate order IDs when creating quotes

## Testing
- `npm test` *(fails: 403 Forbidden fetching nodemon)*

------
https://chatgpt.com/codex/tasks/task_e_684aeced96e48327b1dc217dae97b870