### PR TITLE
Add CRM price rule endpoints

### DIFF
--- a/src/entity/crm/priceRule.ts
+++ b/src/entity/crm/priceRule.ts
@@ -1,0 +1,28 @@
+import { Entity, PrimaryGeneratedColumn, Column, BaseEntity } from "typeorm";
+
+@Entity({ name: "crm_price_rule" })
+export class PriceRule extends BaseEntity {
+  @PrimaryGeneratedColumn()
+  id: number;
+
+  @Column("simple-array", { name: "product_category", nullable: true })
+  productCategory: string[];
+
+  @Column({ nullable: true })
+  field?: string;
+
+  @Column()
+  operator: string;
+
+  @Column({ nullable: true })
+  value?: string;
+
+  @Column("jsonb", { nullable: true })
+  step?: { interval: number; amount: number };
+
+  @Column("text", { nullable: true })
+  code?: string;
+
+  @Column("decimal", { precision: 10, scale: 2, default: 0 })
+  addition: number;
+}

--- a/src/routes/index.ts
+++ b/src/routes/index.ts
@@ -12,6 +12,7 @@ import { AuthRoutes } from "./auth";
 import { OpportunityRoutes } from "./opportunity";
 import { QuoteRoutes } from "./quote";
 import { UserRoutes } from "./user";
+import { PriceRuleRoutes } from "./priceRule";
 
 /**
  * All application routes.
@@ -30,5 +31,6 @@ export const AppRoutes = [
   ...AuthRoutes,
   ...OpportunityRoutes,
   ...QuoteRoutes,
+  ...PriceRuleRoutes,
   ...UserRoutes,
 ];

--- a/src/routes/priceRule.ts
+++ b/src/routes/priceRule.ts
@@ -1,0 +1,39 @@
+import { Request, Response } from "express";
+import { priceRuleService } from "../services/crm/priceRuleService";
+import { authService } from "../services/authService";
+
+const getRules = async (_req: Request, res: Response) => {
+  const rules = await priceRuleService.getRules();
+  res.send(rules);
+};
+
+const createRule = async (req: Request, res: Response) => {
+  const userid = (await authService.verifyToken(req))?.userId;
+  if (!userid) return res.status(401).send("Unauthorized");
+  const { rule } = req.body;
+  const result = await priceRuleService.createRule(rule);
+  res.send(result);
+};
+
+const updateRule = async (req: Request, res: Response) => {
+  const userid = (await authService.verifyToken(req))?.userId;
+  if (!userid) return res.status(401).send("Unauthorized");
+  const { ruleId, rule } = req.body;
+  const result = await priceRuleService.updateRule(ruleId, rule);
+  res.send(result);
+};
+
+const deleteRule = async (req: Request, res: Response) => {
+  const userid = (await authService.verifyToken(req))?.userId;
+  if (!userid) return res.status(401).send("Unauthorized");
+  const ruleId = req.query.ruleId as string;
+  const result = await priceRuleService.deleteRule(ruleId);
+  res.send(result);
+};
+
+export const PriceRuleRoutes = [
+  { path: "/priceRule/get", method: "get", action: getRules },
+  { path: "/priceRule/create", method: "post", action: createRule },
+  { path: "/priceRule/update", method: "post", action: updateRule },
+  { path: "/priceRule/delete", method: "delete", action: deleteRule },
+];

--- a/src/services/crm/priceRuleService.ts
+++ b/src/services/crm/priceRuleService.ts
@@ -1,0 +1,25 @@
+import { PriceRule } from "../../entity/crm/priceRule";
+
+class PriceRuleService {
+  async getRules() {
+    return await PriceRule.find();
+  }
+
+  async createRule(rule: Partial<PriceRule>) {
+    const entity = PriceRule.create(rule);
+    return await entity.save();
+  }
+
+  async updateRule(ruleId: string | number, rule: Partial<PriceRule>) {
+    const id = Number(ruleId);
+    await PriceRule.update({ id }, rule);
+    return await PriceRule.findOne({ where: { id } });
+  }
+
+  async deleteRule(ruleId: string | number) {
+    const id = Number(ruleId);
+    return await PriceRule.delete({ id });
+  }
+}
+
+export const priceRuleService = new PriceRuleService();


### PR DESCRIPTION
## Summary
- implement `crm_price_rule` entity for storing pricing rules
- add CRUD service for price rules
- expose `/priceRule` API endpoints
- register new routes

## Testing
- `npm run build` *(fails: Cannot find module 'typeorm' and other dependencies)*
- `npm test` *(fails: 403 Forbidden when downloading nodemon)*

------
https://chatgpt.com/codex/tasks/task_e_684af0fd53c48327b92f83a24874b898