### PR TITLE
Implement quote sorting by creator and precise timestamp

### DIFF
--- a/src/routes/quote.ts
+++ b/src/routes/quote.ts
@@ -17,6 +17,8 @@ const getQuotes = async (request: Request, response: Response) => {
     type: request.query.type as string,
     quoteName: request.query.quoteName as string,
     customerName: request.query.customerName as string,
+    sortField: request.query.sortField as string,
+    sortOrder: request.query.sortOrder as string as "ASC" | "DESC",
   });
   response.send(quotes);
 };


### PR DESCRIPTION
## Summary
- allow quote lists to be ordered by creator
- expose createdAt in second precision
- pass sorting parameters from route

## Testing
- `npm test` *(fails: E403 Forbidden while fetching nodemon)*

------
https://chatgpt.com/codex/tasks/task_e_684be74c1a3083278ae617aa8f0ba9db