### PR TITLE
Add CRM template backend

### DIFF
--- a/src/entity/crm/template.ts
+++ b/src/entity/crm/template.ts
@@ -1,0 +1,41 @@
+import {
+  Entity,
+  PrimaryGeneratedColumn,
+  Column,
+  BaseEntity,
+  CreateDateColumn,
+  UpdateDateColumn,
+} from "typeorm";
+
+@Entity({ name: "crm_template" })
+export class CrmTemplate extends BaseEntity {
+  @PrimaryGeneratedColumn()
+  id: number;
+
+  @Column()
+  name: string;
+
+  @Column({ nullable: true })
+  description: string;
+
+  @Column("simple-array", { nullable: true })
+  materials: string[];
+
+  @Column("simple-array", { nullable: true })
+  industries: string[];
+
+  @Column({ name: "template_type", nullable: true })
+  templateType: string;
+
+  @Column({ name: "creator_id", nullable: true })
+  creatorId: string;
+
+  @Column("jsonb", { nullable: true })
+  config: any;
+
+  @CreateDateColumn({ name: "created_at" })
+  createdAt: Date;
+
+  @UpdateDateColumn({ name: "updated_at" })
+  updatedAt: Date;
+}

--- a/src/routes/index.ts
+++ b/src/routes/index.ts
@@ -14,6 +14,7 @@ import { QuoteRoutes } from "./quote";
 import { UserRoutes } from "./user";
 import { PriceRuleRoutes } from "./priceRule";
 import { ProductRoutes } from "./product";
+import { TemplateRoutes } from "./template";
 
 /**
  * All application routes.
@@ -32,6 +33,7 @@ export const AppRoutes = [
   ...AuthRoutes,
   ...OpportunityRoutes,
   ...QuoteRoutes,
+  ...TemplateRoutes,
   ...PriceRuleRoutes,
   ...ProductRoutes,
   ...UserRoutes,

--- a/src/routes/template.ts
+++ b/src/routes/template.ts
@@ -1,0 +1,47 @@
+import { Request, Response } from "express";
+import { templateService } from "../services/crm/templateService";
+import { authService } from "../services/authService";
+
+const getTemplates = async (req: Request, res: Response) => {
+  const templates = await templateService.getTemplates({
+    formType: req.query.formType as string,
+  });
+  res.send(templates);
+};
+
+const getTemplate = async (req: Request, res: Response) => {
+  const id = req.query.id as string;
+  const template = await templateService.getTemplate(id);
+  res.send(template);
+};
+
+const createTemplate = async (req: Request, res: Response) => {
+  const userid = (await authService.verifyToken(req))?.userId;
+  if (!userid) return res.status(401).send("Unauthorized");
+  const result = await templateService.createTemplate(req.body);
+  res.send(result);
+};
+
+const updateTemplate = async (req: Request, res: Response) => {
+  const userid = (await authService.verifyToken(req))?.userId;
+  if (!userid) return res.status(401).send("Unauthorized");
+  const { id, ...data } = req.body;
+  const result = await templateService.updateTemplate(id, data);
+  res.send(result);
+};
+
+const deleteTemplate = async (req: Request, res: Response) => {
+  const userid = (await authService.verifyToken(req))?.userId;
+  if (!userid) return res.status(401).send("Unauthorized");
+  const id = req.query.id as string;
+  const result = await templateService.deleteTemplate(id);
+  res.send(result);
+};
+
+export const TemplateRoutes = [
+  { path: "/template/get", method: "get", action: getTemplates },
+  { path: "/template/detail/get", method: "get", action: getTemplate },
+  { path: "/template/create", method: "post", action: createTemplate },
+  { path: "/template/update", method: "post", action: updateTemplate },
+  { path: "/template/delete", method: "delete", action: deleteTemplate },
+];

--- a/src/services/crm/templateService.ts
+++ b/src/services/crm/templateService.ts
@@ -1,0 +1,33 @@
+import { CrmTemplate } from "../../entity/crm/template";
+
+class TemplateService {
+  async getTemplates(params?: { formType?: string }) {
+    const where: any = {};
+    if (params?.formType) {
+      where.templateType = params.formType;
+    }
+    return await CrmTemplate.find({ where });
+  }
+
+  async getTemplate(id: string | number) {
+    return await CrmTemplate.findOne({ where: { id: Number(id) } });
+  }
+
+  async createTemplate(data: Partial<CrmTemplate>) {
+    const entity = CrmTemplate.create(data);
+    return await entity.save();
+  }
+
+  async updateTemplate(id: string | number, data: Partial<CrmTemplate>) {
+    const templateId = Number(id);
+    await CrmTemplate.update({ id: templateId }, data);
+    return await CrmTemplate.findOne({ where: { id: templateId } });
+  }
+
+  async deleteTemplate(id: string | number) {
+    const templateId = Number(id);
+    return await CrmTemplate.delete({ id: templateId });
+  }
+}
+
+export const templateService = new TemplateService();


### PR DESCRIPTION
## Summary
- implement `crm_template` entity with update timestamps
- add template CRUD service and routes
- register template routes with the app router

## Testing
- `npx tsc -p tsconfig.json --noEmit` *(fails: module resolution errors)*
- `npm test` *(fails: 403 Forbidden attempting to download nodemon)*

------
https://chatgpt.com/codex/tasks/task_e_684c3cc34b988327b6ce542a17c82b60