### PR TITLE
Add contract execute endpoint

### DIFF
--- a/src/api/jctimes/contract.ts
+++ b/src/api/jctimes/contract.ts
@@ -1,0 +1,18 @@
+import { ApiClient } from "./api_client";
+
+class JcContractApiClient extends ApiClient {
+  constructor() {
+    super();
+    this.host = "http://122.226.146.110:777";
+  }
+
+  async executeContract(quote: any) {
+    return await this.doRequest({
+      method: "POST",
+      path: "/Contract/Execute",
+      payload: quote,
+    });
+  }
+}
+
+export const jctimesContractApiClient = new JcContractApiClient();

--- a/src/routes/quote.ts
+++ b/src/routes/quote.ts
@@ -5,6 +5,7 @@ import { authService } from "../services/authService";
 import { opportunityServices } from "../services/crm/opportunityService";
 import { productService } from "../services/crm/productService";
 import { quoteService } from "../services/crm/quoteService";
+import { jctimesContractApiClient } from "../api/jctimes/contract";
 const getQuotes = async (request: Request, response: Response) => {
   const userid = (await authService.verifyToken(request))?.userId;
   if (!userid) {
@@ -76,6 +77,21 @@ const deleteQuoteItem = async (request: Request, response: Response) => {
   response.send(quote);
 };
 
+const executeContract = async (request: Request, response: Response) => {
+  const userid = (await authService.verifyToken(request))?.userId;
+  if (!userid) {
+    response.status(401).send("Unauthorized");
+    return;
+  }
+  const { quote } = request.body;
+  if (!quote) {
+    response.status(400).send("Missing quote");
+    return;
+  }
+  const result = await jctimesContractApiClient.executeContract(quote);
+  response.send(result);
+};
+
 export const QuoteRoutes = [
   {
     path: "/quote/create",
@@ -114,5 +130,10 @@ export const QuoteRoutes = [
     path: "/quote/detail/get",
     method: "get",
     action: getQuoteDetail,
+  },
+  {
+    path: "/contract/execute",
+    method: "post",
+    action: executeContract,
   },
 ];


### PR DESCRIPTION
## Summary
- implement new client to POST quotes to 122.226.146.110:777
- expose `/contract/execute` route to forward quote data

## Testing
- `npm test` *(fails: E403 Forbidden - GET https://registry.npmjs.org/nodemon)*

------
https://chatgpt.com/codex/tasks/task_e_684bc96ae2bc8327bb7f33c86d065c90