### PR TITLE
Add sorting support for quote list

### DIFF
--- a/src/routes/quote.ts
+++ b/src/routes/quote.ts
@@ -19,6 +19,7 @@ const getQuotes = async (request: Request, response: Response) => {
       type: request.query.type as string,
       quoteName: request.query.quoteName as string,
       customerName: request.query.customerName as string,
+      sort: request.query.sort as string,
     },
     userid
   );

--- a/src/services/crm/quoteService.ts
+++ b/src/services/crm/quoteService.ts
@@ -289,6 +289,7 @@ class QuoteService {
       type?: string;
       quoteName?: string;
       customerName?: string;
+      sort?: string;
     },
     userid?: string
   ) => {
@@ -298,6 +299,7 @@ class QuoteService {
       type,
       quoteName,
       customerName,
+      sort,
     } = params || {};
 
     const query = Quote.createQueryBuilder("quote");
@@ -323,6 +325,21 @@ class QuoteService {
             .orWhere("quote.salesSupportId = :userid", { userid });
         })
       );
+    }
+
+    if (sort) {
+      const sorts = sort.split(',').filter((v) => v);
+      sorts.forEach((rule, idx) => {
+        const [field, order] = rule.split(':');
+        if (field) {
+          const direction = order && order.toUpperCase() === 'DESC' ? 'DESC' : 'ASC';
+          if (idx === 0) {
+            query.orderBy(`quote.${field}`, direction as any);
+          } else {
+            query.addOrderBy(`quote.${field}`, direction as any);
+          }
+        }
+      });
     }
 
     const [list, total] = await query


### PR DESCRIPTION
## Summary
- accept `sort` query parameter on quote list route
- parse and apply sorting options in `quoteService.getQuotes`

## Testing
- `npm run build` *(fails: Cannot find module)*
- `npm test` *(fails: 403 Forbidden - GET https://registry.npmjs.org/nodemon)*

------
https://chatgpt.com/codex/tasks/task_e_684e962154608327a74ee5fede34be97