### PR TITLE
Implement order retrieval endpoint

### DIFF
--- a/src/controllers/order.controller.ts
+++ b/src/controllers/order.controller.ts
@@ -1,0 +1,22 @@
+import { Request, Response } from "express";
+import { logger } from "../config/logger";
+import { appAxios } from "../utils/fileUtils";
+
+export const getOrderInfo = async (request: Request, response: Response) => {
+  const orderId = request.query.orderId as string;
+  if (!orderId) {
+    return response.status(400).send("Missing orderId");
+  }
+  try {
+    const res = await appAxios({
+      method: "GET",
+      url: "http://122.226.146.110:777/api/GetOrder",
+      params: { ordernum: orderId },
+      timeout: 10000,
+    });
+    response.send(res.data);
+  } catch (error) {
+    logger.error(error);
+    response.status(500).send("Failed to get order info");
+  }
+};

--- a/src/routes/index.ts
+++ b/src/routes/index.ts
@@ -15,6 +15,7 @@ import { UserRoutes } from "./user";
 import { PriceRuleRoutes } from "./priceRule";
 import { ProductRoutes } from "./product";
 import { TemplateRoutes } from "./template";
+import { OrderRoutes } from "./order";
 
 /**
  * All application routes.
@@ -36,5 +37,6 @@ export const AppRoutes = [
   ...TemplateRoutes,
   ...PriceRuleRoutes,
   ...ProductRoutes,
+  ...OrderRoutes,
   ...UserRoutes,
 ];

--- a/src/routes/order.ts
+++ b/src/routes/order.ts
@@ -1,0 +1,9 @@
+import { getOrderInfo } from "../controllers/order.controller";
+
+export const OrderRoutes = [
+  {
+    path: "/order/get",
+    method: "get",
+    action: getOrderInfo,
+  },
+];


### PR DESCRIPTION
## Summary
- add controller for fetching order information from external service
- register `/order/get` endpoint

## Testing
- `npm test` *(fails: 403 Forbidden when trying to download packages)*

------
https://chatgpt.com/codex/tasks/task_e_685593b9fd688327947406f4eb8ca38a