### PR TITLE
Add product part entity and search route

### DIFF
--- a/src/entity/crm/productPart.ts
+++ b/src/entity/crm/productPart.ts
@@ -1,0 +1,28 @@
+import { Entity, PrimaryColumn, Column, BaseEntity } from "typeorm";
+
+@Entity({ name: "crm_product_part" })
+export class ProductPart extends BaseEntity {
+  @PrimaryColumn()
+  id: string;
+
+  @Column()
+  name: string;
+
+  @Column({ nullable: true })
+  category: string;
+
+  @Column({
+    type: "decimal",
+    precision: 12,
+    scale: 2,
+    nullable: true,
+  })
+  price: number;
+
+  @Column({ nullable: true })
+  unit: string;
+
+  @Column({ type: "char", length: 1 })
+  type: "P" | "M";
+}
+

--- a/src/routes/product.ts
+++ b/src/routes/product.ts
@@ -1,5 +1,6 @@
 import { Request, Response } from "express";
 import { productService } from "../services/crm/productService";
+import { partService } from "../services/crm/partService";
 import { authService } from "../services/authService";
 
 const searchProducts = async (request: Request, response: Response) => {
@@ -12,6 +13,17 @@ const searchProducts = async (request: Request, response: Response) => {
   const field = (request.query.field as "code" | "name") ?? "name";
   const formType = (request.query.formType as string) ?? "";
   const result = await productService.searchProducts(keyword, field, formType);
+  response.send(result);
+};
+
+const searchParts = async (request: Request, response: Response) => {
+  const userid = (await authService.verifyToken(request))?.userId;
+  if (!userid) {
+    response.status(401).send("Unauthorized");
+    return;
+  }
+  const keyword = (request.query.keyword as string) ?? "";
+  const result = await partService.searchParts(keyword);
   response.send(result);
 };
 
@@ -54,5 +66,10 @@ export const ProductRoutes = [
       const data = await productService.getFilter();
       response.send(data);
     },
+  },
+  {
+    path: "/product/part/search",
+    method: "get",
+    action: searchParts,
   },
 ];

--- a/src/services/crm/partService.ts
+++ b/src/services/crm/partService.ts
@@ -1,0 +1,19 @@
+import { Like } from "typeorm";
+import { ProductPart } from "../../entity/crm/productPart";
+
+class PartService {
+  async searchParts(keyword: string): Promise<ProductPart[]> {
+    if (!keyword) {
+      return [];
+    }
+    return ProductPart.find({
+      where: [
+        { name: Like(`%${keyword}%`) },
+        { category: Like(`%${keyword}%`) },
+      ],
+    });
+  }
+}
+
+export const partService = new PartService();
+


### PR DESCRIPTION
## Summary
- support product part search
- define `ProductPart` entity
- add service to query product parts

## Testing
- `npm test` *(fails: 403 Forbidden fetching packages)*
- `npm run build` *(fails to install dependencies)*

------
https://chatgpt.com/codex/tasks/task_e_6857ea80174c8327ac8dbc57cc5537bd