### PR TITLE
Implement print file management for quotes

### DIFF
--- a/src/entity/crm/quote.ts
+++ b/src/entity/crm/quote.ts
@@ -131,6 +131,9 @@ export class Quote extends BaseEntity {
   @Column({ name: "config_pdf", nullable: true })
   configPdf: string;
 
+  @Column({ name: "need_print", default: true })
+  needPrint: boolean;
+
   @Column({ name: "contact_name", nullable: true })
   contactName: string; // 联系人姓名
 

--- a/src/services/crm/quoteService.ts
+++ b/src/services/crm/quoteService.ts
@@ -12,6 +12,8 @@ import { getManager, In, IsNull, Not, Brackets } from "typeorm";
 import { customerServices } from "./customerService";
 import { PgDataSource } from "../../config/data-source";
 import { Customer } from "../../entity/crm/customer";
+import { jctimesContractApiClient } from "../../api/jctimes/contract";
+import { downloadFile } from "../../utils/fileUtils";
 
 class QuoteService {
   appid = "6191e49fc6c18500070f60ca";
@@ -315,9 +317,10 @@ class QuoteService {
     }).save();
   };
 
-  updateQuote = async (quote: Quote) => {
+  updateQuote = async (quote: Quote, submit = false) => {
+    quote.needPrint = true;
     const saved = await Quote.save(quote);
-    if (quote.jdyId) {
+    if (submit && quote.jdyId) {
       await this.updateJdyFromQuote(saved);
     }
     return saved;
@@ -340,11 +343,34 @@ class QuoteService {
     //   const parent = await QuoteItem.findOne({ where: { id: parentId } });
     //   if (parent) quoteItem.parent = parent;
     // }
-    return await quoteItem.save();
+    const saved = await quoteItem.save();
+    await Quote.update({ id: quoteId }, { needPrint: true });
+    return saved;
   };
 
   removeQuoteItem = async (quoteItemId) => {
+    const item = await QuoteItem.findOne({ where: { id: quoteItemId } });
+    if (item) {
+      await Quote.update({ id: item.quoteId }, { needPrint: true });
+    }
     return await QuoteItem.delete(quoteItemId);
+  };
+
+  printQuote = async (quoteId: number) => {
+    const quote = await Quote.findOne({ where: { id: quoteId }, relations: ["items"] });
+    if (!quote) return null;
+    if (!quote.needPrint) return quote;
+
+    const result: any = await jctimesContractApiClient.executeContract(quote);
+    if (result) {
+      const base = `./public/files/quote/${quote.id}`;
+      quote.configPdf = await downloadFile(result.configPdf, `${base}/config.pdf`);
+      quote.quotationPdf = await downloadFile(result.quotationPdf, `${base}/quotation.pdf`);
+      quote.contractPdf = await downloadFile(result.contractPdf, `${base}/contract.pdf`);
+    }
+    quote.needPrint = false;
+    await quote.save();
+    return quote;
   };
 
   getQuotes = async (


### PR DESCRIPTION
## Summary
- update quote update API to accept `submit` flag for JDY updates
- track print status with new `need_print` column on quotes
- add printing service that generates files via `executeContract`
- create endpoints to download quote print files
- verify user permission when downloading files and refresh print files if needed

## Testing
- `npm run build` *(fails: Cannot find module 'fs' or its corresponding type declarations)*
- `npm test` *(fails: 403 Forbidden - GET https://registry.npmjs.org/nodemon)*

Codex couldn't run certain commands due to environment limitations. Consider configuring a setup script or internet access in your Codex environment to install dependencies.

------
https://chatgpt.com/codex/tasks/task_e_68596213c3988327b854364eb8c57e79