### PR TITLE
Add pagination to template list API

### DIFF
--- a/src/routes/template.ts
+++ b/src/routes/template.ts
@@ -5,6 +5,8 @@ import { authService } from "../services/authService";
 const getTemplates = async (req: Request, res: Response) => {
   const templates = await templateService.getTemplates({
     formType: req.query.formType as string,
+    page: parseInt(req.query.page as string),
+    pageSize: parseInt(req.query.pageSize as string),
   });
   res.send(templates);
 };

--- a/src/services/crm/templateService.ts
+++ b/src/services/crm/templateService.ts
@@ -1,12 +1,21 @@
 import { CrmTemplate } from "../../entity/crm/template";
 
 class TemplateService {
-  async getTemplates(params?: { formType?: string }) {
-    const where: any = {};
-    if (params?.formType) {
-      where.templateType = params.formType;
+  async getTemplates(params?: {
+    formType?: string;
+    page?: number;
+    pageSize?: number;
+  }) {
+    const { formType, page = 1, pageSize = 20 } = params || {};
+    const query = CrmTemplate.createQueryBuilder("template");
+    if (formType) {
+      query.where("template.templateType = :formType", { formType });
     }
-    return await CrmTemplate.find({ where });
+    const [list, total] = await query
+      .skip((page - 1) * pageSize)
+      .take(pageSize)
+      .getManyAndCount();
+    return { list, total };
   }
 
   async getTemplate(id: string | number) {


### PR DESCRIPTION
## Summary
- add pagination to template service
- parse page and pageSize query params in template route

## Testing
- `npm test` *(fails: 403 Forbidden - GET https://registry.npmjs.org/nodemon)*

------
https://chatgpt.com/codex/tasks/task_e_6863fc63a56483279f2301c5e3baac44