### PR TITLE
Add order matching for quote items

### DIFF
--- a/src/entity/crm/quote.ts
+++ b/src/entity/crm/quote.ts
@@ -207,6 +207,9 @@ export class QuoteItem extends BaseEntity {
   @Column({ name: "product_code", nullable: true })
   productCode: string; // 产品编码
 
+  @Column({ name: "order_product_name", nullable: true })
+  orderProductName: string; // 订单中匹配到的产品名称
+
   @Column({ name: "form_type", nullable: true })
   formType: string; // 表单类型
 

--- a/src/routes/quote.ts
+++ b/src/routes/quote.ts
@@ -159,6 +159,19 @@ export const QuoteRoutes = [
     action: deleteQuoteItem,
   },
   {
+    path: "/quote/fillItemProduct",
+    method: "post",
+    action: async (request: Request, response: Response) => {
+      const userid = (await authService.verifyToken(request))?.userId;
+      if (!userid) {
+        response.status(401).send("Unauthorized");
+        return;
+      }
+      await quoteService.fillItemsFromOrders();
+      response.send("ok");
+    },
+  },
+  {
     path: "/category/get",
     method: "get",
     action: async (request: Request, response: Response) => {

--- a/src/utils/stringUtils.ts
+++ b/src/utils/stringUtils.ts
@@ -12,3 +12,30 @@ export function removeUndefined(obj) {
     )
   );
 }
+
+export function levenshtein(a: string, b: string): number {
+  const matrix = Array.from({ length: a.length + 1 }, () =>
+    new Array(b.length + 1).fill(0)
+  );
+  for (let i = 0; i <= a.length; i++) matrix[i][0] = i;
+  for (let j = 0; j <= b.length; j++) matrix[0][j] = j;
+  for (let i = 1; i <= a.length; i++) {
+    for (let j = 1; j <= b.length; j++) {
+      const cost = a[i - 1] === b[j - 1] ? 0 : 1;
+      matrix[i][j] = Math.min(
+        matrix[i - 1][j] + 1,
+        matrix[i][j - 1] + 1,
+        matrix[i - 1][j - 1] + cost
+      );
+    }
+  }
+  return matrix[a.length][b.length];
+}
+
+export function similarity(a: string, b: string): number {
+  if (!a || !b) return 0;
+  const len = Math.max(a.length, b.length);
+  if (len === 0) return 1;
+  const distance = levenshtein(a, b);
+  return (len - distance) / len;
+}


### PR DESCRIPTION
## Summary
- add `orderProductName` column to `QuoteItem`
- add string similarity helper with Levenshtein
- add service method `fillItemsFromOrders` to populate missing product codes
- expose `/quote/fillItemProduct` endpoint to trigger update

## Testing
- `npm test` *(fails: 403 Forbidden - GET https://registry.npmjs.org/nodemon)*

------
https://chatgpt.com/codex/tasks/task_e_686499f845fc8327a13d817fb2f5db2b