### PR TITLE
Implement quote item share

### DIFF
--- a/src/entity/crm/quoteItemShare.ts
+++ b/src/entity/crm/quoteItemShare.ts
@@ -1,0 +1,41 @@
+import {
+  Entity,
+  PrimaryGeneratedColumn,
+  Column,
+  BaseEntity,
+  CreateDateColumn,
+  UpdateDateColumn,
+} from "typeorm";
+
+@Entity({ name: "crm_quote_item_share" })
+export class QuoteItemShare extends BaseEntity {
+  @PrimaryGeneratedColumn()
+  id: number;
+
+  @Column({ name: "quote_item_id" })
+  quoteItemId: number;
+
+  @Column({ unique: true })
+  uuid: string;
+
+  @Column()
+  pwd: string;
+
+  @Column({ name: "user_id" })
+  userId: string;
+
+  @Column({ default: false })
+  editable: boolean;
+
+  @Column({ default: false })
+  disabled: boolean;
+
+  @Column({ name: "expires_at", type: "timestamp", nullable: true })
+  expiresAt: Date;
+
+  @CreateDateColumn({ name: "created_at" })
+  createdAt: Date;
+
+  @UpdateDateColumn({ name: "updated_at" })
+  updatedAt: Date;
+}

--- a/src/routes/index.ts
+++ b/src/routes/index.ts
@@ -11,6 +11,7 @@ import { CustomerRoutes } from "./customer";
 import { AuthRoutes } from "./auth";
 import { OpportunityRoutes } from "./opportunity";
 import { QuoteRoutes } from "./quote";
+import { QuoteItemShareRoutes } from "./quoteItemShare";
 import { UserRoutes } from "./user";
 import { QuoteRuleRoutes } from "./quoteRule";
 import { RuleRoutes } from "./rule";
@@ -35,6 +36,7 @@ export const AppRoutes = [
   ...AuthRoutes,
   ...OpportunityRoutes,
   ...QuoteRoutes,
+  ...QuoteItemShareRoutes,
   ...TemplateRoutes,
   ...QuoteRuleRoutes,
   ...RuleRoutes,

--- a/src/routes/quoteItemShare.ts
+++ b/src/routes/quoteItemShare.ts
@@ -1,0 +1,82 @@
+import { Request, Response } from "express";
+import { authService } from "../services/authService";
+import { quoteItemShareService } from "../services/crm/quoteItemShareService";
+import { User } from "../entity/basic/employee";
+
+const createShare = async (req: Request, res: Response) => {
+  const userid = (await authService.verifyToken(req))?.userId;
+  if (!userid) return res.status(401).send("Unauthorized");
+  const { quoteItemId, expiresAt, editable } = req.body;
+  const { uuid, pwd } = await quoteItemShareService.createShareLink(
+    Number(quoteItemId),
+    userid,
+    new Date(expiresAt),
+    editable
+  );
+  res.send({ uuid, pwd });
+};
+
+const getLinks = async (req: Request, res: Response) => {
+  const userid = (await authService.verifyToken(req))?.userId;
+  if (!userid) return res.status(401).send("Unauthorized");
+  const quoteItemId = Number(req.query.quoteItemId as string);
+  const data = await quoteItemShareService.getShareLinks(quoteItemId, userid);
+  res.send(data);
+};
+
+const getShare = async (req: Request, res: Response) => {
+  const uuid = req.query.uuid as string;
+  const pwd = req.query.pwd as string;
+  const data = await quoteItemShareService.getShare(uuid, pwd);
+  if (!data) return res.status(404).send("Not Found");
+  const user = await User.findOne({ where: { user_id: data.shareUserId } });
+  if (!('quoteItem' in data)) {
+    return res.status(410).send({
+      expiredAt: (data as any).expiredAt,
+      shareUserName: user?.name,
+    });
+  }
+  res.send({
+    quoteItem: (data as any).quoteItem,
+    quoteId: (data as any).quoteId,
+    editable: (data as any).editable,
+    shareUserName: user?.name,
+  });
+};
+
+const disableShare = async (req: Request, res: Response) => {
+  const userid = (await authService.verifyToken(req))?.userId;
+  if (!userid) return res.status(401).send("Unauthorized");
+  const { quoteItemId } = req.body;
+  await quoteItemShareService.disableShare(Number(quoteItemId), userid);
+  res.send("ok");
+};
+
+const updateExpire = async (req: Request, res: Response) => {
+  const userid = (await authService.verifyToken(req))?.userId;
+  if (!userid) return res.status(401).send("Unauthorized");
+  const { uuid, expiresAt } = req.body;
+  const result = await quoteItemShareService.updateExpire(
+    uuid,
+    userid,
+    new Date(expiresAt)
+  );
+  if (!result) return res.status(404).send("Not Found");
+  res.send("ok");
+};
+
+const saveShare = async (req: Request, res: Response) => {
+  const { uuid, shareUserId, quoteItem } = req.body;
+  const result = await quoteItemShareService.saveShare(uuid, shareUserId, quoteItem);
+  if (!result) return res.status(400).send("Invalid uuid or user");
+  res.send(result);
+};
+
+export const QuoteItemShareRoutes = [
+  { path: "/quoteItem/share", method: "post", action: createShare },
+  { path: "/quoteItem/share", method: "get", action: getLinks },
+  { path: "/quoteItem/share/detail", method: "get", action: getShare },
+  { path: "/quoteItem/share/disable", method: "post", action: disableShare },
+  { path: "/quoteItem/share/expire", method: "post", action: updateExpire },
+  { path: "/quoteItem/share/save", method: "post", action: saveShare },
+];

--- a/src/services/crm/quoteItemShareService.ts
+++ b/src/services/crm/quoteItemShareService.ts
@@ -1,0 +1,131 @@
+import { randomBytes } from "crypto";
+import { QuoteItem } from "../../entity/crm/quote";
+import { QuoteItemShare } from "../../entity/crm/quoteItemShare";
+import { User } from "../../entity/basic/employee";
+
+class QuoteItemShareService {
+  private async generateUuid(): Promise<string> {
+    let uuid: string;
+    do {
+      uuid = randomBytes(5)
+        .toString("base64")
+        .replace(/[^a-zA-Z0-9]/g, "")
+        .slice(0, 6);
+    } while (await QuoteItemShare.findOne({ where: { uuid } }));
+    return uuid;
+  }
+
+  private generatePwd(): string {
+    return Math.floor(Math.random() * 10000)
+      .toString()
+      .padStart(4, "0");
+  }
+
+  async createShareLink(
+    quoteItemId: number,
+    userId: string,
+    expiresAt: Date,
+    editable = false
+  ) {
+    let share = await QuoteItemShare.findOne({
+      where: { quoteItemId, userId, editable, disabled: false },
+    });
+    if (!share) {
+      share = QuoteItemShare.create({
+        quoteItemId,
+        userId,
+        editable,
+        disabled: false,
+      });
+    }
+    const now = new Date();
+    let expireDate = expiresAt ? new Date(expiresAt) : new Date(now.getTime() + 5 * 86400000);
+    const diff = (expireDate.getTime() - now.getTime()) / 86400000;
+    if (diff > 5) expireDate = new Date(now.getTime() + 5 * 86400000);
+    if (diff < 0) expireDate = new Date(now.getTime() + 86400000);
+    share.uuid = await this.generateUuid();
+    share.pwd = await this.generatePwd();
+    share.expiresAt = expireDate;
+    await share.save();
+    return { uuid: share.uuid, pwd: share.pwd };
+  }
+
+  async getShare(uuid: string, pwd: string) {
+    const share = await QuoteItemShare.findOne({
+      where: { uuid, pwd, disabled: false },
+    });
+    if (!share) return null;
+    if (share.expiresAt && share.expiresAt.getTime() < Date.now()) {
+      return { expiredAt: share.expiresAt, shareUserId: share.userId };
+    }
+    const quoteItem = await QuoteItem.findOne({ where: { id: share.quoteItemId } });
+    if (!quoteItem) return null;
+    return {
+      quoteItem,
+      quoteId: quoteItem.quoteId,
+      editable: share.editable,
+      shareUserId: share.userId,
+    };
+  }
+
+  async getShareLinks(quoteItemId: number, userId: string) {
+    const shares = await QuoteItemShare.find({
+      where: { quoteItemId, userId, disabled: false },
+    });
+    const view = shares.find((s) => !s.editable);
+    const edit = shares.find((s) => s.editable);
+    return {
+      viewUuid: view?.uuid,
+      viewPwd: view?.pwd,
+      editUuid: edit?.uuid,
+      editPwd: edit?.pwd,
+      expireDays: view?.expiresAt
+        ? Math.ceil((view.expiresAt.getTime() - Date.now()) / 86400000)
+        : undefined,
+    };
+  }
+
+  async disableShare(quoteItemId: number, userId: string) {
+    await QuoteItemShare.update(
+      { quoteItemId, userId },
+      { disabled: true }
+    );
+  }
+
+  async updateExpire(
+    uuid: string,
+    userId: string,
+    expiresAt: Date
+  ) {
+    const share = await QuoteItemShare.findOne({
+      where: { uuid, userId, disabled: false },
+    });
+    if (!share) return null;
+    const now = new Date();
+    let expireDate = expiresAt ? new Date(expiresAt) : new Date(now.getTime() + 5 * 86400000);
+    const diff = (expireDate.getTime() - now.getTime()) / 86400000;
+    if (diff > 5) expireDate = new Date(now.getTime() + 5 * 86400000);
+    if (diff < 0) expireDate = new Date(now.getTime() + 86400000);
+    share.expiresAt = expireDate;
+    await share.save();
+    return share;
+  }
+
+  async saveShare(
+    uuid: string,
+    shareUserId: string,
+    quoteItem: Partial<QuoteItem>
+  ) {
+    const share = await QuoteItemShare.findOne({
+      where: { uuid, disabled: false },
+    });
+    if (!share) return null;
+    if (share.expiresAt && share.expiresAt.getTime() < Date.now()) return null;
+    const user = await User.findOne({ where: { user_id: shareUserId } });
+    if (!user) return null;
+    await QuoteItem.update({ id: share.quoteItemId }, quoteItem);
+    return await QuoteItem.findOne({ where: { id: share.quoteItemId } });
+  }
+}
+
+export const quoteItemShareService = new QuoteItemShareService();


### PR DESCRIPTION
## Summary
- add `disabled` field on `crm_quote_item_share`
- generate share passwords without duplicate checks and allow updating expiry
- mark shares disabled instead of deleting when disabling
- adjust share link expiration logic to handle absolute dates

## Testing
- `npm run build` *(fails: Cannot find module 'fs' or its corresponding type declarations)*

Codex couldn't run certain commands due to environment limitations. Consider configuring a setup script or internet access in your Codex environment to install dependencies.

------
https://chatgpt.com/codex/tasks/task_e_68669a8bdd5483278824d3691c6e5e80