### PR TITLE
Add remark and consolidate PDF paths

### DIFF
--- a/src/entity/crm/quote.ts
+++ b/src/entity/crm/quote.ts
@@ -146,8 +146,8 @@ export class Quote extends BaseEntity {
   @Column({ name: "telephone", nullable: true })
   telephone: string; // 产品名称
 
-  @Column("jsonb", { name: "file", nullable: true })
-  file: any; // 打印相关文件
+  @Column("jsonb", { name: "files", nullable: true })
+  files: any; // 打印相关文件
 
   @Column({ type: "text", nullable: true })
   remark: string; // 备注

--- a/src/routes/quote.ts
+++ b/src/routes/quote.ts
@@ -134,10 +134,10 @@ const sendPrintFile = (key: "config" | "quotation" | "contract") => {
     }
     const file =
       key === "config"
-        ? quote.file?.configPdf
+        ? quote.files?.configPdf
         : key === "quotation"
-        ? quote.file?.quotationPdf
-        : quote.file?.contractPdf;
+        ? quote.files?.quotationPdf
+        : quote.files?.contractPdf;
     if (!file) {
       response.status(404).send("Not Found");
       return;

--- a/src/services/crm/quoteService.ts
+++ b/src/services/crm/quoteService.ts
@@ -434,7 +434,7 @@ class QuoteService {
         result.productConfiguration,
         `${base}/contract.pdf`
       );
-      quote.file = { configPdf, quotationPdf, contractPdf };
+      quote.files = { configPdf, quotationPdf, contractPdf };
     }
     quote.needPrint = false;
     await quote.save();


### PR DESCRIPTION
## Summary
- add jsonb `file` column for quote PDFs
- restore other print fields and keep boolean `needPrint`
- update service logic to use new `file` column
- route handlers now read PDF paths from `file`

## Testing
- `npm test` *(fails: 403 Forbidden while downloading nodemon)*

------
https://chatgpt.com/codex/tasks/task_e_686f5f56bc8c832797c94e99f65ea3a7