### PR TITLE
Notify users when day-off quota is exhausted

### DIFF
--- a/src/schedule/sendLeave.ts
+++ b/src/schedule/sendLeave.ts
@@ -119,14 +119,20 @@ export const sendtoUserwithLeaveChoice = async () => {
   for (const key in allQuota) {
     const quota = allQuota[key];
     if (quota.total >= 5) {
-      if (isEqual(sunday, startOfMonth(sunday))) {
-        quota.left = quota.left + 1;
-      }
       const user = await getUser(key);
       if (user && user.userid.length < 19) {
-        // console.log(user, quota.left);
-        await sendLeave(user, quota.left);
-        await sleep(100);
+        if (quota.left === 0) {
+          await new MessageService([user.userid]).send_plain_text(
+            "轮休假已用完，本周末没有轮休假 如需请假，请走薪福通-请假流程"
+          );
+        } else {
+          if (isEqual(sunday, startOfMonth(sunday))) {
+            quota.left = quota.left + 1;
+          }
+          // console.log(user, quota.left);
+          await sendLeave(user, quota.left);
+          await sleep(100);
+        }
       }
     }
   }

--- a/src/services/xft/quotaServices.ts
+++ b/src/services/xft/quotaServices.ts
@@ -38,7 +38,7 @@ class QuotaServices {
       .filter((item) => item.stfNumber) // 过滤掉 stfNumber 为空的项
       .groupBy("stfNumber") // 按 stfNumber 分组
       .mapValues((items) => this.getSingleDayOffQuotaLeft(items)) // 获取每个分组的项目
-      .pickBy((value) => value.left !== null && value.left !== 0)
+      .pickBy((value) => value.left !== null)
       .value();
     return result;
   }


### PR DESCRIPTION
## Summary
- include employees with zero remaining day-off quota when retrieving quotas
- send plain text notice if an employee's day-off quota is used up

## Testing
- `npm test` *(fails: started nodemon watcher but no tests run)*

------
https://chatgpt.com/codex/tasks/task_e_68bfd907acc48327ae4c09f16aba6dc1