### PR TITLE
Load WeChat corp configs from repo `wechat.json` and remove .env fallbacks

### DIFF
--- a/src/features/wechat/api/token.ts
+++ b/src/features/wechat/api/token.ts
@@ -82,8 +82,7 @@ const ensureToken = (config: TokenConfig): Token => {
 };
 
 wechatCorpConfigs.forEach((config) => {
-  ensureToken({ corp_id: config.corpId, corp_secret: config.corpSecret });
-  config.apps?.forEach((app) => {
+  config.apps.forEach((app) => {
     ensureToken({ corp_id: config.corpId, corp_secret: app.corpSecret });
   });
 });

--- a/src/scripts/validateWechatConfig.ts
+++ b/src/scripts/validateWechatConfig.ts
@@ -3,11 +3,15 @@ import { logger } from "../config/logger";
 
 const validateConfigs = () => {
   if (!wechatCorpConfigs.length) {
-    throw new Error("No WeChat corp configuration found. Set WECHAT_CORP_CONFIGS or legacy CORP_ID/CORP_SECRET/WECHAT_ENCODING_AES_KEY.");
+    throw new Error("No WeChat corp configuration found. Provide wechat.json.");
   }
 
   const invalid = wechatCorpConfigs.filter(
-    (config) => !config.corpId || !config.corpSecret || !config.encodingAESKey
+    (config) =>
+      !config.corpId ||
+      !config.name ||
+      !config.apps.length ||
+      config.apps.some((app) => !app.agentId || !app.corpSecret || !app.name)
   );
 
   if (invalid.length > 0) {


### PR DESCRIPTION
### Motivation
- Centralize WeChat configuration in a single repository file instead of environment JSON to match runtime expectations and the user's request to read `wechat.json` directly.  
- Eliminate legacy environment-variable fallbacks so app/corp secrets and names are explicit in the config.  
- Make caller behavior predictable by resolving missing inputs to sensible defaults (`jctimes` / `OA`).

### Description
- Read configuration from the repo-root `wechat.json` using `fs`/`path` in `src/config/wechatCorps.ts` and log a clear error when the file is missing or fails to parse.  
- Remove legacy env-based fallbacks and fallback corp-level secrets; parse each corp entry to require `name` and parse each app to require `agentId`, `corpSecret`, and `name`.  
- Add `defaultCorpName` and `defaultAppName` constants and update `getCorpConfig`/`getCorpAppConfig` to resolve to those defaults when inputs are missing and to return an empty `corpSecret` when no matching app is found.  
- Change token prewarm behavior to only prewarm tokens for configured apps (iterate `config.apps.forEach`) and update validation messaging in `src/scripts/validateWechatConfig.ts` to reference `wechat.json` and the tightened validation rules.

### Testing
- No automated tests were run on these changes.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_697a2ff837748327b3c6c8a044f83c20)